### PR TITLE
fix CRC for data > 4GB (fixes #30)

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -8,7 +8,7 @@ use ffi;
 
 pub struct Crc {
     crc: libc::c_ulong,
-    amt: u32,
+    amt: usize,
 }
 
 pub struct CrcReader<R> {
@@ -25,12 +25,12 @@ impl Crc {
         self.crc
     }
 
-    pub fn amt(&self) -> u32 {
+    pub fn amt(&self) -> usize {
         self.amt
     }
 
     pub fn update(&mut self, data: &[u8]) {
-        self.amt += data.len() as u32;
+        self.amt += data.len();
         self.crc = unsafe {
             ffi::mz_crc32(self.crc, data.as_ptr(), data.len() as libc::size_t)
         };

--- a/src/gz.rs
+++ b/src/gz.rs
@@ -446,9 +446,9 @@ impl<R: Read> DecoderReader<R> {
         let crc = ((buf[0] as u32) << 0) | ((buf[1] as u32) << 8) |
                   ((buf[2] as u32) << 16) |
                   ((buf[3] as u32) << 24);
-        let amt = ((buf[4] as u32) << 0) | ((buf[5] as u32) << 8) |
-                  ((buf[6] as u32) << 16) |
-                  ((buf[7] as u32) << 24);
+        let amt = ((buf[4] as usize) << 0) | ((buf[5] as usize) << 8) |
+                  ((buf[6] as usize) << 16) |
+                  ((buf[7] as usize) << 24);
         if crc != self.inner.crc().sum() as u32 {
             return Err(corrupt());
         }


### PR DESCRIPTION
`libc::size_t = usize` anyway.