### PR TITLE
Bump to 0.2.11, fixed miniz dep version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.2.10"
+version = "0.2.11"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["gzip", "flate", "zlib", "encoding"]
@@ -17,7 +17,7 @@ streams.
 
 [dependencies]
 libc = "0.2"
-miniz-sys = { path = "miniz-sys", version = "0.1.6" }
+miniz-sys = { path = "miniz-sys", version = "0.1.7" }
 
 [dev-dependencies]
 rand = "0.3"


### PR DESCRIPTION
this creates a working combination of the miniz-sys crate and libc. 0.2.10 sadly is bogus

CI doesn’t capture this bug since it just uses the miniz-sys crate under the path instead of fetching the specified version from crates.io. we need to fix that as well!

The bug is because 0.2.10 [requires `miniz-sys 0.16`](https://github.com/alexcrichton/flate2-rs/commit/e013dace27c4f4d754681a675c0b5d1b8a30b412#diff-80398c5faae3c069e4e6aa2ed11b28c0L20), which [requires `libc 0.1`](https://github.com/alexcrichton/flate2-rs/blob/c494b5ea1be244df9de43a0aa93f0c848e7cfcef/miniz-sys/Cargo.toml#L19), which has [`type size_t = u64`](https://github.com/rust-lang-nursery/libc/blob/dafaca90f0950c17e81e420172b9661c77d128fb/src/lib.rs#L1055).

this ends up creating a compile error when putting `flate2 = "^0.2.10"` in my Cargo.toml :cry: 