### PR TITLE
Remove unnecessary trait bounds from reader types definitions

### DIFF
--- a/src/zlib.rs
+++ b/src/zlib.rs
@@ -20,7 +20,7 @@ pub struct EncoderWriter<W: Write> {
 ///
 /// This structure implements a `Read` interface and will read uncompressed
 /// data from an underlying stream and emit a stream of compressed data.
-pub struct EncoderReader<R: Read> {
+pub struct EncoderReader<R> {
     inner: EncoderReaderBuf<BufReader<R>>,
 }
 
@@ -28,7 +28,7 @@ pub struct EncoderReader<R: Read> {
 ///
 /// This structure implements a `BufRead` interface and will read uncompressed
 /// data from an underlying stream and emit a stream of compressed data.
-pub struct EncoderReaderBuf<R: BufRead> {
+pub struct EncoderReaderBuf<R> {
     obj: R,
     data: Compress,
 }
@@ -37,7 +37,7 @@ pub struct EncoderReaderBuf<R: BufRead> {
 ///
 /// This structure implements a `Read` interface and takes a stream of
 /// compressed data as input, providing the decompressed data when read from.
-pub struct DecoderReader<R: Read> {
+pub struct DecoderReader<R> {
     inner: DecoderReaderBuf<BufReader<R>>,
 }
 
@@ -45,7 +45,7 @@ pub struct DecoderReader<R: Read> {
 ///
 /// This structure implements a `BufRead` interface and takes a stream of
 /// compressed data as input, providing the decompressed data when read from.
-pub struct DecoderReaderBuf<R: BufRead> {
+pub struct DecoderReaderBuf<R> {
     obj: R,
     data: Decompress,
 }


### PR DESCRIPTION
It is not necessary for reader types to bind type parameters with `std::io::Read` at the type definition (for example, see [std::io::Take](https://doc.rust-lang.org/std/io/struct.Take.html)).

Writer types requires restrictions such as `W: Write` at the type definition, but reader types do not.
These needless restrictions should be removed.