### PR TITLE
Expose the underlying mz_stream from Compress and Decompress.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,11 @@ pub mod bufread {
     pub use gz::DecoderReaderBuf as GzDecoder;
 }
 
+/// Raw C structs from miniz or libz.
+pub mod raw {
+    pub use ffi::mz_stream;
+}
+
 fn _assert_send_sync() {
     fn _assert_send_sync<T: Send + Sync>() {}
 

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -170,6 +170,11 @@ impl Compress {
         }
     }
 
+    /// Get the raw state of the underlying compressor.
+    pub fn get_raw(&mut self) -> *mut ffi::mz_stream {
+        &mut self.inner.raw as *mut ffi::mz_stream
+    }
+
     /// Returns the total number of input bytes which have been processed by
     /// this compression object.
     pub fn total_in(&self) -> u64 {
@@ -280,6 +285,11 @@ impl Decompress {
                 },
             }
         }
+    }
+
+    /// Get the raw state of the underlying decompressor.
+    pub fn get_raw(&mut self) -> *mut ffi::mz_stream {
+        &mut self.inner.raw as *mut ffi::mz_stream
     }
 
     /// Returns the total number of input bytes which have been processed by


### PR DESCRIPTION
zlib exposes more API surface than miniz, and I needed to use a few of those APIs (like inflateReset),
but using the libz-sys crate directly means I have to reimplement a number of things from flate2.

Really all I need is to be able to get the underlying mz_stream so I can call the zlib APIs on it.
This patch adds a `get_raw` method to Compress and Decompress that returns a `*mut mz_state` which can
be passed directly to the functions defined in libz-sys. This doesn't add much complexity to flate2, but
fixes my niche use case.