### PR TITLE
Add flush_finish()

### DIFF
--- a/src/deflate.rs
+++ b/src/deflate.rs
@@ -89,10 +89,22 @@ impl<W: Write> EncoderWriter<W> {
 
     /// Consumes this encoder, flushing the output stream.
     ///
-    /// This will flush the underlying data stream and then return the contained
-    /// writer if the flush succeeded.
+    /// This will flush the underlying data stream, close off the compressed
+    /// stream and, if successful, return the contained writer.
     pub fn finish(mut self) -> io::Result<W> {
         try!(self.inner.finish());
+        Ok(self.inner.into_inner())
+    }
+
+    /// Consumes this encoder, flushing the output stream.
+    ///
+    /// This will flush the underlying data stream and then return the contained
+    /// writer if the flush succeeded.
+    /// The compressed stream will not closed but only flushed. This
+    /// means that obtained byte array can by extended by another deflated
+    /// stream. To close the stream add the two bytes 0x3 and 0x0.
+    pub fn flush_finish(mut self) -> io::Result<W> {
+        try!(self.inner.flush());
         Ok(self.inner.into_inner())
     }
 }


### PR DESCRIPTION
This function is useful for creating deflated blocks that can be concatenated.

And that in turn is useful for deflating a stream in parallel.
