### PR TITLE
Make Crc and CrcReader public and add a combine method.

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -6,29 +6,36 @@ use libc;
 
 use ffi;
 
+/// The CRC calculated by a CrcReader.
 pub struct Crc {
     crc: libc::c_ulong,
     amt: u32,
 }
 
+/// A wrapper around a `std::io::Read` that calculates the CRC.
 pub struct CrcReader<R> {
     inner: R,
     crc: Crc,
 }
 
 impl Crc {
+    /// Create a new CRC.
     pub fn new() -> Crc {
         Crc { crc: 0, amt: 0 }
     }
 
+    /// bla
     pub fn sum(&self) -> u32 {
         self.crc as u32
     }
 
-    pub fn amt_as_u32(&self) -> u32 {
+    /// The number of bytes that have been used to calculate the CRC.
+    /// This value is only accurate if the amount is lower than 2^32.
+    pub fn amount(&self) -> u32 {
         self.amt
     }
 
+    /// Update the CRC with the bytes in `data`.
     pub fn update(&mut self, data: &[u8]) {
         self.amt = self.amt.wrapping_add(data.len() as u32);
         self.crc = unsafe {
@@ -36,13 +43,25 @@ impl Crc {
         };
     }
 
+    /// Reset the CRC.
     pub fn reset(&mut self) {
         self.crc = 0;
         self.amt = 0;
     }
+
+    /// Combine the CRC with the CRC for the subsequent block of bytes.
+    pub fn combine(&mut self, additional_crc: &Crc) {
+        self.crc = unsafe {
+            ffi::mz_crc32_combine(self.crc as ::libc::c_ulong,
+                                  additional_crc.crc as ::libc::c_ulong,
+                                  additional_crc.amt as ::libc::off_t)
+        };
+        self.amt += additional_crc.amt;
+    }
 }
 
 impl<R: Read> CrcReader<R> {
+    /// Create a new CrcReader.
     pub fn new(r: R) -> CrcReader<R> {
         CrcReader {
             inner: r,
@@ -50,22 +69,27 @@ impl<R: Read> CrcReader<R> {
         }
     }
 
+    /// Get the Crc for this CrcReader.
     pub fn crc(&self) -> &Crc {
         &self.crc
     }
 
+    /// Get the reader that is wrapped by this CrcReader.
     pub fn into_inner(self) -> R {
         self.inner
     }
 
+    /// Get the reader that is wrapped by this CrcReader by reference.
     pub fn get_ref(&self) -> &R {
         &self.inner
     }
 
+    /// Get a mutable reference to the reader that is wrapped by this CrcReader.
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.inner
     }
 
+    /// Reset the Crc in this CrcReader.
     pub fn reset(&mut self) {
         self.crc.reset();
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -38,6 +38,12 @@ mod imp {
         z::crc32(crc, ptr, len as c_uint)
     }
 
+    pub unsafe extern fn mz_crc32_combine(crc1: c_ulong,
+                                          crc2: c_ulong,
+                                          len2: z_off_t) -> c_ulong {
+          z::crc32_combine(crc1, crc2, len2)
+    }
+
     const ZLIB_VERSION: &'static str = "1.2.8\0";
 
     pub unsafe extern fn mz_deflateInit2(stream: *mut mz_stream,
@@ -92,6 +98,7 @@ mod imp {
     use std::mem;
     use std::ops::{Deref, DerefMut};
 
+    use libc::{c_ulong, off_t};
     pub use self::miniz_sys::*;
 
     pub struct StreamWrapper {
@@ -119,4 +126,98 @@ mod imp {
             &mut self.inner
         }
     }
+
+    pub unsafe extern fn mz_crc32_combine(crc1: c_ulong,
+                                          crc2: c_ulong,
+                                          len2: off_t) -> c_ulong {
+          crc32_combine_(crc1, crc2, len2)
+    }
+
+    // gf2_matrix_times, gf2_matrix_square and crc32_combine_ are ported from
+    // zlib.
+
+    fn gf2_matrix_times(mat: &[c_ulong; 32], mut vec: c_ulong) -> c_ulong {
+        let mut sum = 0;
+        let mut mat_pos = 0;
+        while vec != 0 {
+            if vec & 1 == 1 {
+                sum ^= mat[mat_pos];
+            }
+            vec >>= 1;
+            mat_pos += 1;
+        }
+        sum
+    }
+
+    fn gf2_matrix_square(square: &mut [c_ulong; 32], mat: &[c_ulong; 32]) {
+        for n in 0..32 {
+            square[n] = gf2_matrix_times(mat, mat[n]);
+        }
+    }
+
+    fn crc32_combine_(mut crc1: c_ulong, crc2: c_ulong, mut len2: off_t) -> c_ulong {
+        let mut row;
+
+        let mut even = [0; 32]; /* even-power-of-two zeros operator */
+        let mut odd = [0; 32]; /* odd-power-of-two zeros operator */
+
+        /* degenerate case (also disallow negative lengths) */
+        if len2 <= 0 {
+            return crc1;
+        }
+
+        /* put operator for one zero bit in odd */
+        odd[0] = 0xedb88320;          /* CRC-32 polynomial */
+        row = 1;
+        for n in 1..32 {
+            odd[n] = row;
+            row <<= 1;
+        }
+
+        /* put operator for two zero bits in even */
+        gf2_matrix_square(&mut even, &odd);
+
+        /* put operator for four zero bits in odd */
+        gf2_matrix_square(&mut odd, &even);
+
+        /* apply len2 zeros to crc1 (first square will put the operator for one
+           zero byte, eight zero bits, in even) */
+        loop {
+            /* apply zeros operator for this bit of len2 */
+            gf2_matrix_square(&mut even, &odd);
+            if len2 & 1 == 1 {
+                crc1 = gf2_matrix_times(&even, crc1);
+            }
+            len2 >>= 1;
+
+            /* if no more bits set, then done */
+            if len2 == 0 {
+                break;
+            }
+
+            /* another iteration of the loop with odd and even swapped */
+            gf2_matrix_square(&mut odd, &even);
+            if len2 & 1 == 1 {
+                crc1 = gf2_matrix_times(&odd, crc1);
+            }
+            len2 >>= 1;
+
+            /* if no more bits set, then done */
+            if len2 == 0 {
+                break;
+            }
+        }
+
+        /* return combined crc */
+        crc1 ^= crc2;
+        crc1
+    }
+}
+
+#[test]
+fn crc32_combine() {
+    let crc32 = unsafe {
+        imp::mz_crc32_combine(1, 2, 3)
+    };
+    assert_eq!(crc32, 29518389);
 }

--- a/src/gz.rs
+++ b/src/gz.rs
@@ -269,7 +269,7 @@ impl<W: Write> EncoderWriter<W> {
         }
         try!(self.inner.finish());
         let mut inner = self.inner.get_mut().unwrap();
-        let (sum, amt) = (self.crc.sum() as u32, self.crc.amt_as_u32());
+        let (sum, amt) = (self.crc.sum() as u32, self.crc.amount());
         let buf = [(sum >> 0) as u8,
                    (sum >> 8) as u8,
                    (sum >> 16) as u8,
@@ -391,10 +391,10 @@ impl<R: BufRead> EncoderReaderBuf<R> {
                        (crc.sum() >> 8) as u8,
                        (crc.sum() >> 16) as u8,
                        (crc.sum() >> 24) as u8,
-                       (crc.amt_as_u32() >> 0) as u8,
-                       (crc.amt_as_u32() >> 8) as u8,
-                       (crc.amt_as_u32() >> 16) as u8,
-                       (crc.amt_as_u32() >> 24) as u8];
+                       (crc.amount() >> 0) as u8,
+                       (crc.amount() >> 8) as u8,
+                       (crc.amount() >> 16) as u8,
+                       (crc.amount() >> 24) as u8];
         Ok(copy(into, arr, &mut self.pos))
     }
 }
@@ -574,7 +574,7 @@ impl<R: BufRead> DecoderReaderBuf<R> {
         if crc != self.inner.crc().sum() as u32 {
             return Err(corrupt());
         }
-        if amt != self.inner.crc().amt_as_u32() {
+        if amt != self.inner.crc().amount() {
             return Err(corrupt());
         }
         self.finished = true;
@@ -661,7 +661,7 @@ impl<R: BufRead> MultiDecoderReaderBuf<R> {
         if crc != self.inner.crc().sum() as u32 {
             return Err(corrupt());
         }
-        if amt != self.inner.crc().amt_as_u32() {
+        if amt != self.inner.crc().amount() {
             return Err(corrupt());
         }
         let remaining = match self.inner.get_mut().get_mut().fill_buf() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ use std::io;
 pub use gz::Builder as GzBuilder;
 pub use gz::Header as GzHeader;
 pub use mem::{Compress, Decompress, DataError, Status, Flush};
+pub use crc::{Crc, CrcReader};
 
 mod bufreader;
 mod crc;


### PR DESCRIPTION
The method crc32_combine from zlib is used. For minizip, a version of
crc32_combine is used that was ported from libz.