### PR TITLE
Added a .gitattributes to configure how files are handled in git.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# automatically handle text files
+* text=auto
+
+# text files
+*.md text
+*.txt text
+
+# source code files
+*.rs text
+*.c text
+
+# configuration files
+*.yml text
+*.toml text
+
+# compressed files
+*.gz binary
+
+# no end-of-line normalization should take place for integration test text files
+tests/*.txt -text


### PR DESCRIPTION
Checking out flate2-rs under windows with autocrlf=true results in some of the integration tests failing. This is because the uncompressed text files are undergoing end-of-line normalization while the archive contents still contain the LF line-endings, this results in the test assertions failing.

By using a .gitattributes file it is possible to ensure the integration test text files do not undergo end-of-line normalization.