### PR TITLE
Added compression examples

### DIFF
--- a/examples/gzbuilder.rs
+++ b/examples/gzbuilder.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use std::fs::File;
+use flate2::GzBuilder;
+use flate2::Compression;
+
+// Open file and debug print the contents compressed with gzip
+fn main() {
+    sample_builder().unwrap();
+}
+
+// GzBuilder opens a file and writes a sample string using Builder pattern
+fn sample_builder() -> Result<(), io::Error> {
+    let f = File::create("examples/hello_world.gz")?;
+    let mut gz = GzBuilder::new()
+                 .filename("hello_world.txt")
+                 .comment("test file, please delete")
+                 .write(f, Compression::Default);
+    gz.write(b"hello world")?;
+    gz.finish()?;
+    Ok(())
+}

--- a/examples/gzdecoder-bufread.rs
+++ b/examples/gzdecoder-bufread.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use flate2::bufread::GzDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = GzEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_reader(bytes).unwrap());
+}
+
+// Uncompresses a Gz Encoded vector of bytes and returns a string or error
+// Here &[u8] implements BufRead
+fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut gz = GzDecoder::new(&bytes[..])?;
+    let mut s = String::new();
+    gz.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/examples/gzdecoder-read.rs
+++ b/examples/gzdecoder-read.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use flate2::read::GzDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = GzEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_reader(bytes).unwrap());
+}
+
+// Uncompresses a Gz Encoded vector of bytes and returns a string or error
+// Here &[u8] implements Read
+fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut gz = GzDecoder::new(&bytes[..])?;
+    let mut s = String::new();
+    gz.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/examples/gzencoder-bufread.rs
+++ b/examples/gzencoder-bufread.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::bufread::GzEncoder;
+use std::fs::File;
+use std::io::BufReader;
+
+// Open file and debug print the contents compressed with gzip
+fn main() {
+    println!("{:?}", open_hello_world().unwrap());
+}
+
+// Opens sample file, compresses the contents and returns a Vector or error
+// File wrapped in a BufReader implements Bufread
+fn open_hello_world() -> io::Result<Vec<u8>> {
+    let f = File::open("examples/hello_world.txt")?;
+    let b = BufReader::new(f);
+    let mut gz = GzEncoder::new(b, Compression::Fast);
+    let mut buffer = Vec::new();
+    gz.read_to_end(&mut buffer)?;
+    Ok(buffer)
+}

--- a/examples/gzencoder-read.rs
+++ b/examples/gzencoder-read.rs
@@ -1,0 +1,20 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::read::GzEncoder;
+
+// Print the GZ compressed representation of hello world
+fn main() {
+    println!("{:?}", gzencoder_read_hello_world().unwrap());
+}
+
+// Return a vector containing the GZ compressed version of hello world
+fn gzencoder_read_hello_world() -> io::Result<Vec<u8>> {
+    let mut ret_vec = [0;100];
+    let c = b"hello world";
+    let mut z = GzEncoder::new(&c[..], Compression::Fast);
+    let count = z.read(&mut ret_vec)?;
+    Ok(ret_vec[0..count].to_vec())
+}

--- a/examples/gzencoder-write.rs
+++ b/examples/gzencoder-write.rs
@@ -1,0 +1,12 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+
+// Vec<u8> implements Write to print the compressed bytes of sample string
+fn main() {
+    let mut e = GzEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    println!("{:?}", e.finish().unwrap());
+}

--- a/examples/gzmultidecoder-bufread.rs
+++ b/examples/gzmultidecoder-bufread.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use flate2::bufread::MultiGzDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = GzEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_reader(bytes).unwrap());
+}
+
+// Uncompresses a Gz Encoded vector of bytes and returns a string or error
+// Here &[u8] implements BufRead
+fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut gz = MultiGzDecoder::new(&bytes[..])?;
+    let mut s = String::new();
+    gz.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/examples/gzmultidecoder-read.rs
+++ b/examples/gzmultidecoder-read.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use flate2::read::MultiGzDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = GzEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_reader(bytes).unwrap());
+}
+
+// Uncompresses a Gz Encoded vector of bytes and returns a string or error
+// Here &[u8] implements Read
+fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut gz = MultiGzDecoder::new(&bytes[..])?;
+    let mut s = String::new();
+    gz.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/examples/hello_world.txt
+++ b/examples/hello_world.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/examples/zlibdecoder-bufread.rs
+++ b/examples/zlibdecoder-bufread.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use flate2::bufread::ZlibDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_bufreader(bytes).unwrap());
+}
+
+// Uncompresses a Zlib Encoded vector of bytes and returns a string or error
+// Here &[u8] implements BufRead
+fn decode_bufreader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut z = ZlibDecoder::new(&bytes[..]);
+    let mut s = String::new();
+    z.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/examples/zlibdecoder-read.rs
+++ b/examples/zlibdecoder-read.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use flate2::read::ZlibDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_reader(bytes).unwrap());
+}
+
+// Uncompresses a Zlib Encoded vector of bytes and returns a string or error
+// Here &[u8] implements Read
+fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut z = ZlibDecoder::new(&bytes[..]);
+    let mut s = String::new();
+    z.read_to_string(&mut s)?;
+    Ok(s)
+}

--- a/examples/zlibdecoder-write.rs
+++ b/examples/zlibdecoder-write.rs
@@ -1,0 +1,26 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+use flate2::write::ZlibDecoder;
+
+// Compress a sample string and print it after transformation.
+fn main() {
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    let bytes = e.finish().unwrap();
+    println!("{}", decode_reader(bytes).unwrap());
+}
+
+// Uncompresses a Zlib Encoded vector of bytes and returns a string or error
+// Here Vec<u8> implements Write
+fn decode_reader(bytes: Vec<u8>) -> io::Result<String> {
+    let mut writer = Vec::new();
+    let mut z = ZlibDecoder::new(writer);
+    z.write(&bytes[..])?;
+    writer = z.finish()?;
+    let return_string = String::from_utf8(writer).expect("String parsing error");
+    Ok(return_string)
+}

--- a/examples/zlibencoder-bufread.rs
+++ b/examples/zlibencoder-bufread.rs
@@ -1,0 +1,24 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use std::io;
+use flate2::Compression;
+use flate2::bufread::ZlibEncoder;
+use std::fs::File;
+use std::io::BufReader;
+
+// Open file and debug print the contents compressed with zlib
+fn main() {
+    println!("{:?}", open_hello_world().unwrap());
+}
+
+// Opens sample file, compresses the contents and returns a Vector or error
+// File wrapped in a BufReader implements Bufread
+fn open_hello_world() -> io::Result<Vec<u8>> {
+    let f = File::open("examples/hello_world.txt")?;
+    let b = BufReader::new(f);
+    let mut z = ZlibEncoder::new(b, Compression::Fast);
+    let mut buffer = Vec::new();
+    z.read_to_end(&mut buffer)?;
+    Ok(buffer)
+}

--- a/examples/zlibencoder-read.rs
+++ b/examples/zlibencoder-read.rs
@@ -1,0 +1,21 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use flate2::Compression;
+use flate2::read::ZlibEncoder;
+use std::fs::File;
+
+// Open file and debug print the compressed contents
+fn main() {
+    println!("{:?}", open_hello_world().unwrap());
+}
+
+// Opens sample file, compresses the contents and returns a Vector or error
+// File implements Read
+fn open_hello_world() -> std::io::Result<Vec<u8>> {
+    let f = File::open("examples/hello_world.txt")?;
+    let mut z = ZlibEncoder::new(f, Compression::Fast);
+    let mut buffer = [0;50];
+    let byte_count = z.read(&mut buffer)?;
+    Ok(buffer[0..byte_count].to_vec())
+}

--- a/examples/zlibencoder-write.rs
+++ b/examples/zlibencoder-write.rs
@@ -1,0 +1,12 @@
+extern crate flate2;
+
+use std::io::prelude::*;
+use flate2::Compression;
+use flate2::write::ZlibEncoder;
+
+// Vec<u8> implements Write to print the compressed bytes of sample string
+fn main() {
+    let mut e = ZlibEncoder::new(Vec::new(), Compression::Default);
+    e.write(b"Hello World").unwrap();
+    println!("{:?}", e.finish().unwrap());
+}


### PR DESCRIPTION
For #76 
NOT FINISHED
Before completing the decompression examples, and possibly adding other methods to the examples, I was hoping for a code review to confirm these are desired.  

```bash
cargo run --example zlibencoder-bufread
cargo doc
```