### PR TITLE
Documentation - Mention rust backend & update miniz and flate info

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@
 [![Documentation](https://docs.rs/flate2/badge.svg)](https://docs.rs/flate2)
 
 A streaming compression/decompression library for Rust. The underlying
-implementation by default uses [`miniz`](https://code.google.com/p/miniz/) but
+implementation by default uses [`miniz`](https://github.com/richgel999/miniz) but
 can optionally be configured to use the system zlib, if available.
+
+There is also an experimental rust backend that uses the
+[`miniz_oxide`](https://crates.io/crates/miniz_oxide) crate. This avoids the need
+to build C code, but hasn't gone through as much testing as the other backends.
 
 Supported formats:
 
@@ -26,6 +30,13 @@ Using zlib instead of miniz:
 ```toml
 [dependencies]
 flate2 = { version = "0.2", features = ["zlib"], default-features = false }
+```
+
+Using the rust back-end:
+
+```toml
+[dependencies]
+flate2 = { version = "0.2", features = ["rust_backend"], default-features = false }
 ```
 
 ## Compression

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,13 +1,14 @@
 //! A DEFLATE-based stream compression/decompression library
 //!
-//! This library is meant to supplement/replace the standard distributon's
-//! libflate library by providing a streaming encoder/decoder rather than purely
+//! This library is meant to supplement/replace the
+//! `flate` library that was previously part of the standard rust distribution
+//! providing a streaming encoder/decoder rather than purely
 //! an in-memory encoder/decoder.
 //!
-//! Like with [`libflate`], flate2 is based on [`miniz.c`][1]
+//! Like with [`flate`], flate2 is based on [`miniz.c`][1]
 //!
-//! [1]: https://code.google.com/p/miniz/
-//! [`libflate`]: https://docs.rs/crate/libflate/
+//! [1]: https://github.com/richgel999/miniz
+//! [`flate`]: https://github.com/rust-lang/rust/tree/1.19.0/src/libflate
 //!
 //! # Organization
 //!


### PR DESCRIPTION
Note that there is now a rust back-end. (Granted a version with it hasn't been published yet so I don't know if this should be changed until that's ready.)

Point the miniz link to the new github page instead of the removed google code one.

Mention that the flate library is no longer part of the rust compiler, and fix the link so it doesn't point to the wrong library.
The libflate library on crates.io is a different library so I removed the lib prefix in the documentation here to avoid confusion.

Not sure if a link to flate is really needed but I did a simple replacement for now.