### PR TITLE
Fix pulldown diff

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -36,7 +36,7 @@ impl Crc {
     }
 
     /// The number of bytes that have been used to calculate the CRC.
-    /// This value is only accurate if the amount is lower than 2^32.
+    /// This value is only accurate if the amount is lower than 2<sup>32</sup>.
     pub fn amount(&self) -> u32 {
         self.amt
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@
 //! This crate consists mainly of three modules, [`read`], [`write`], and
 //! [`bufread`]. Each module contains a number of types used to encode and
 //! decode various streams of data. All types in the [`write`] module work on
-//! instances of [`Write`], whereas all types in the [`read`] module work on
-//! instances of [`Read`] and [`bufread`] works with [`BufRead`].
+//! instances of [`Write`][write], whereas all types in the [`read`] module work on
+//! instances of [`Read`][read] and [`bufread`] works with [`BufRead`][bufread].
 //!
 //! ```
 //! use flate2::write::GzEncoder;
@@ -43,9 +43,9 @@
 //! [`read`]: read/index.html
 //! [`bufread`]: bufread/index.html
 //! [`write`]: write/index.html
-//! [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-//! [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-//! [`BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html
+//! [read]: https://doc.rust-lang.org/std/io/trait.Read.html
+//! [write]: https://doc.rust-lang.org/std/io/trait.Write.html
+//! [bufread]: https://doc.rust-lang.org/std/io/trait.BufRead.html
 //!
 //! # Async I/O
 //!


### PR DESCRIPTION
For the other output differences such as:

```
WARNING: rendering difference in `A DEFLATE-based stream compression/decompression library`
   --> src/lib.rs:1:0
    /html[0]/body[1]/p[4] Attributes differ in `a`: expected: `{"href": "bufread/index.html"}`, found: `{"href": "https://doc.rust-lang.org/std/io/trait.BufRead.html"}`
```

It's because in the old rustdoc markdown renderer, `[read] == [Read]`. So it's actually a *good* thing to have them.

EDIT: Ah, my bad. It's still an issue but a different one. Will be fixed in rustdoc so no need to change this.

EDIT of EDIT: The commonmark spec says:

> As noted in the section on Links, matching of labels is case-insensitive (see matches).

You can see it [here](http://spec.commonmark.org/0.27/#link-reference-definition).

So I fixed them as well.