### PR TITLE
Emit a RFC 1952 compatible XFL flag again

### DIFF
--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -236,7 +236,13 @@ impl GzBuilder {
         header[5] = (mtime >> 8) as u8;
         header[6] = (mtime >> 16) as u8;
         header[7] = (mtime >> 24) as u8;
-        header[8] = lvl.0 as u8;
+        header[8] = if lvl.0 >= Compression::best().0 {
+            2
+        } else if lvl.0 <= Compression::fast().0 {
+            4
+        } else {
+            0
+        };
 
         // Typically this byte indicates what OS the gz stream was created on,
         // but in an effort to have cross-platform reproducible streams just


### PR DESCRIPTION
RFC 1952 specifies the following values
for the XFL flag:

* 2: maximum compression, slowest
* 4: fastest algorithm config

Commit 7e0390b51336b9737eefb10d1afc14d5e311fb9d has
changed our behaviour from conforming to that
to setting the XFL flag to 9 when compression
is best, and 0 when it is the fastest one.

We revert that change in order to have consistent
output with pre 1.0.0 versions of flate2 and also
to be consistent with RFC 1952 and the ecosystem
around it, e.g. unix tooling that assumes the
RFC specified layout for the XFL flag.

Fixes #137.