### PR TITLE
Add gz::write::GzDecoder

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -34,7 +34,7 @@ fn read_le_u16<R: Read>(r: &mut R) -> io::Result<u16> {
     Ok((b[0] as u16) | ((b[1] as u16) << 8))
 }
 
-fn read_gz_header<R: Read>(r: &mut R) -> io::Result<GzHeader> {
+pub fn read_gz_header<R: Read>(r: &mut R) -> io::Result<GzHeader> {
     let mut crc_reader = CrcReader::new(r);
     let mut header = [0; 10];
     try!(crc_reader.read_exact(&mut header));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@ pub mod write {
     pub use zlib::write::ZlibEncoder;
     pub use zlib::write::ZlibDecoder;
     pub use gz::write::GzEncoder;
+    pub use gz::write::GzDecoder;
 }
 
 /// Types which operate over [`BufRead`] streams, both encoders and decoders for

--- a/tests/gunzip.rs
+++ b/tests/gunzip.rs
@@ -57,3 +57,18 @@ fn extract_file_multi(path_compressed: &Path) -> io::Result<Vec<u8>>{
     try!(MultiGzDecoder::new(f).read_to_end(&mut v));
     Ok(v)
 }
+
+// Test writing and reading a gz stream via std::io::Write
+#[test]
+fn test_gz_write() {
+    let buf = Vec::new();
+    let mut w = flate2::write::GzEncoder::new(buf, flate2::Compression::new(0));
+    let content = b"one two three four five";
+    w.write_all(content).expect("could not write to gz");
+    let gz = w.finish().unwrap();
+    let buf = Vec::new();
+    let mut w = flate2::write::GzDecoder::new(buf);
+    w.write_all(&gz).expect("could write to gz decoder");
+    let out = w.finish().unwrap();
+    assert_eq!(content, &out[..]);
+}


### PR DESCRIPTION
First stab at implementing gz::write::GzDecoder. It does not do crc check and the test hangs.

Should solve https://github.com/alexcrichton/flate2-rs/issues/113.