### PR TITLE
Workaround to avoid having miniz_oxide_c_api export symbols that collide with miniz-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ miniz-sys = { path = "miniz-sys", version = "0.1.7", optional = true }
 libz-sys = { version = "1.0", optional = true }
 tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
-miniz_oxide_c_api = { version = "0.1", optional = true}
+miniz_oxide_c_api = { version = "0.1", optional = true, features = ["no_c_export"]}
 
 [dev-dependencies]
 rand = "0.3"


### PR DESCRIPTION
For projects that have dependencies on both 0.2 and 1.0 versions of flate2 (particularly with zip-rs since it defaults to using the rust back-end). I didn't manage to trigger this myself, but someone else did: https://gitter.im/rust-lang/rust?at=5a57cc7183152df26d5d5cfc

This should hopefully avoid this for now. The c api wrapping was mainly used for ease of integration, ideally we would avoid it entirely for the rust backend, though that would be a much bigger change.