### PR TITLE
Add tests for reading with an empty buffer, and fix bug in GzDecoder

### DIFF
--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -358,6 +358,9 @@ impl<R: BufRead> Read for GzDecoder<R> {
             let another_error = io::ErrorKind::Other.into();
             return Err(mem::replace(e, another_error));
         }
+        if into.is_empty() {
+            return Ok(0);
+        }
         match try!(self.inner.read(into)) {
             0 => {
                 try!(self.finish());

--- a/tests/empty-read.rs
+++ b/tests/empty-read.rs
@@ -1,0 +1,81 @@
+extern crate flate2;
+
+use std::io::{Read, Write};
+
+#[test]
+fn deflate_decoder_empty_read() {
+    let original: &[u8] = b"Lorem ipsum dolor sit amet.";
+    let mut encoder = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(original).unwrap();
+    let encoded: Vec<u8> = encoder.finish().unwrap();
+    let mut decoder = flate2::read::DeflateDecoder::new(encoded.as_slice());
+    assert_eq!(decoder.read(&mut []).unwrap(), 0);
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded.as_slice(), original);
+}
+
+#[test]
+fn deflate_encoder_empty_read() {
+    let original: &[u8] = b"Lorem ipsum dolor sit amet.";
+    let mut encoder = flate2::read::DeflateEncoder::new(original, flate2::Compression::default());
+    assert_eq!(encoder.read(&mut []).unwrap(), 0);
+    let mut encoded = Vec::new();
+    encoder.read_to_end(&mut encoded).unwrap();
+    let mut decoder = flate2::read::DeflateDecoder::new(encoded.as_slice());
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded.as_slice(), original);
+}
+
+#[test]
+fn gzip_decoder_empty_read() {
+    let original: &[u8] = b"Lorem ipsum dolor sit amet.";
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(original).unwrap();
+    let encoded: Vec<u8> = encoder.finish().unwrap();
+    let mut decoder = flate2::read::GzDecoder::new(encoded.as_slice());
+    assert_eq!(decoder.read(&mut []).unwrap(), 0);
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded.as_slice(), original);
+}
+
+#[test]
+fn gzip_encoder_empty_read() {
+    let original: &[u8] = b"Lorem ipsum dolor sit amet.";
+    let mut encoder = flate2::read::GzEncoder::new(original, flate2::Compression::default());
+    assert_eq!(encoder.read(&mut []).unwrap(), 0);
+    let mut encoded = Vec::new();
+    encoder.read_to_end(&mut encoded).unwrap();
+    let mut decoder = flate2::read::GzDecoder::new(encoded.as_slice());
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded.as_slice(), original);
+}
+
+#[test]
+fn zlib_decoder_empty_read() {
+    let original: &[u8] = b"Lorem ipsum dolor sit amet.";
+    let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(original).unwrap();
+    let encoded: Vec<u8> = encoder.finish().unwrap();
+    let mut decoder = flate2::read::ZlibDecoder::new(encoded.as_slice());
+    assert_eq!(decoder.read(&mut []).unwrap(), 0);
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded.as_slice(), original);
+}
+
+#[test]
+fn zlib_encoder_empty_read() {
+    let original: &[u8] = b"Lorem ipsum dolor sit amet.";
+    let mut encoder = flate2::read::ZlibEncoder::new(original, flate2::Compression::default());
+    assert_eq!(encoder.read(&mut []).unwrap(), 0);
+    let mut encoded = Vec::new();
+    encoder.read_to_end(&mut encoded).unwrap();
+    let mut decoder = flate2::read::ZlibDecoder::new(encoded.as_slice());
+    let mut decoded = Vec::new();
+    decoder.read_to_end(&mut decoded).unwrap();
+    assert_eq!(decoded.as_slice(), original);
+}

--- a/tests/empty-read.rs
+++ b/tests/empty-read.rs
@@ -5,7 +5,8 @@ use std::io::{Read, Write};
 #[test]
 fn deflate_decoder_empty_read() {
     let original: &[u8] = b"Lorem ipsum dolor sit amet.";
-    let mut encoder = flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
+    let mut encoder =
+        flate2::write::DeflateEncoder::new(Vec::new(), flate2::Compression::default());
     encoder.write_all(original).unwrap();
     let encoded: Vec<u8> = encoder.finish().unwrap();
     let mut decoder = flate2::read::DeflateDecoder::new(encoded.as_slice());
@@ -18,7 +19,8 @@ fn deflate_decoder_empty_read() {
 #[test]
 fn deflate_encoder_empty_read() {
     let original: &[u8] = b"Lorem ipsum dolor sit amet.";
-    let mut encoder = flate2::read::DeflateEncoder::new(original, flate2::Compression::default());
+    let mut encoder =
+        flate2::read::DeflateEncoder::new(original, flate2::Compression::default());
     assert_eq!(encoder.read(&mut []).unwrap(), 0);
     let mut encoded = Vec::new();
     encoder.read_to_end(&mut encoded).unwrap();


### PR DESCRIPTION
I recently ran into a problem where I was wrapping a `flate2::read::GzDecoder` inside another reader, and the outer reader ended up calling `read()` on the `GzDecoder` with an empty buffer, and instead of just returning `Ok(0)`, the `GzDecoder` returned an `InvalidInput` error with the message: `"corrupt gzip stream does not have a matching checksum"`.

Here's a simple test case to reproduce (without the need for the outer writer):

```rust
extern crate flate2;

// Compress some data with gzip:
let original: &[u8] = b"Lorem ipsum dolor sit amet.";
let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
encoder.write_all(original).unwrap();
let encoded: Vec<u8> = encoder.finish().unwrap();

// Now decompress it again:
let mut decoder = flate2::read::GzDecoder::new(encoded.as_slice());
assert_eq!(decoder.read(&mut []).unwrap(), 0);  // This call to read() fails
let mut decoded = Vec::new();
decoder.read_to_end(&mut decoded).unwrap();
assert_eq!(decoded.as_slice(), original);
```

The contract for [`Read::read()`](https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read) doesn't seem to *require* implementations to return `Ok(0)` when the buffer is empty (instead of blocking or returning an error), but it seems like the nice thing to do.  Even if `GzDecoder` wanted to return an error in this case, "corrupt gzip stream does not have a matching checksum" is definitely misleading (and in fact, it took me some time to track down the cause).

Interestingly, the other `Read` impls in `flate2` seem to handle `read(&mut [])` just fine (e.g. if you replace `Gz` with `Zlib` in the above test); it's just `GzDecoder` that breaks.

This PR adds a simple 3-line fix for `GzDecoder`, along with a bunch of unit tests.