### PR TITLE
Recommend using bufread types for decoding `&[u8]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,12 @@
 //!
 //! This crate consists mainly of three modules, [`read`], [`write`], and
 //! [`bufread`]. Each module contains a number of types used to encode and
-//! decode various streams of data. All types in the [`write`] module work on
-//! instances of [`Write`][write], whereas all types in the [`read`] module work on
-//! instances of [`Read`][read] and [`bufread`] works with [`BufRead`][bufread].
+//! decode various streams of data.
+//!
+//! All types in the [`write`] module work on instances of [`Write`][write],
+//! whereas all types in the [`read`] module work on instances of
+//! [`Read`][read] and [`bufread`] works with [`BufRead`][bufread]. If you
+//! are decoding directly from a `&[u8]`, use the [`bufread`] types.
 //!
 //! ```
 //! use flate2::write::GzEncoder;


### PR DESCRIPTION
Not sure it's worth mentioning, but I was wondering about it and would have appreciated a note.