### PR TITLE
[WIP] Initial wasm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ matrix:
     - rust: stable
       script: cargo run --manifest-path systest/Cargo.toml
 
+    - rust: nightly
+      install: rustup target add wasm32-unknown-unknown
+      script: cargo build --target wasm32-unknown-unknown
+
     - rust: stable
       env: RUST_BACKEND=1
       script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 miniz_oxide_c_api = { version = "0.1", optional = true, features = ["no_c_export"]}
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+miniz_oxide_c_api = { version = "0.1", optional = false, features = ["no_c_export"]}
+
 [dev-dependencies]
 rand = "0.5"
 quickcheck = { version = "0.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ tokio-io = { version = "0.1", optional = true }
 futures = { version = "0.1", optional = true }
 miniz_oxide_c_api = { version = "0.1", optional = true, features = ["no_c_export"]}
 
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))'.dependencies]
 miniz_oxide_c_api = { version = "0.1", features = ["no_c_export"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures = { version = "0.1", optional = true }
 miniz_oxide_c_api = { version = "0.1", optional = true, features = ["no_c_export"]}
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-miniz_oxide_c_api = { version = "0.1", optional = false, features = ["no_c_export"]}
+miniz_oxide_c_api = { version = "0.1", features = ["no_c_export"] }
 
 [dev-dependencies]
 rand = "0.5"
@@ -44,3 +44,6 @@ tokio = ["tokio-io", "futures"]
 [badges]
 travis-ci = { repository = "alexcrichton/flate2-rs" }
 appveyor = { repository = "alexcrichton/flate2-rs" }
+
+[patch.crates-io]
+miniz_oxide_c_api = { git = 'https://github.com/Frommi/miniz_oxide' }

--- a/miniz-sys/build.rs
+++ b/miniz-sys/build.rs
@@ -4,6 +4,9 @@ use std::env;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+    if target == "wasm32-unknown-unknown" {
+        return
+    }
     let mut build = cc::Build::new();
     build.file("miniz.c")
         .define("MINIZ_NO_STDIO", None)

--- a/miniz-sys/lib.rs
+++ b/miniz-sys/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/miniz-sys/0.1")]
 #![allow(bad_style)]
+#![cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 
 extern crate libc;
 use libc::*;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -108,7 +108,7 @@ mod imp {
     }
 }
 
-#[cfg(any(all(not(feature = "zlib"), feature = "rust_backend"), target_arch="wasm32"))]
+#[cfg(any(all(not(feature = "zlib"), feature = "rust_backend"), all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 mod imp {
     extern crate miniz_oxide_c_api;
     use std::ops::{Deref, DerefMut};
@@ -137,7 +137,7 @@ mod imp {
     }
 }
 
-#[cfg(all(not(feature = "zlib"), not(feature = "rust_backend"), not(target_arch="wasm32")))]
+#[cfg(all(not(feature = "zlib"), not(feature = "rust_backend"), not(all(target_arch = "wasm32", not(target_os = "emscripten")))))]
 mod imp {
     extern crate miniz_sys;
     use std::mem;

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -108,7 +108,7 @@ mod imp {
     }
 }
 
-#[cfg(all(not(feature = "zlib"), feature = "rust_backend"))]
+#[cfg(any(all(not(feature = "zlib"), feature = "rust_backend"), target_arch="wasm32"))]
 mod imp {
     extern crate miniz_oxide_c_api;
     use std::ops::{Deref, DerefMut};
@@ -137,7 +137,7 @@ mod imp {
     }
 }
 
-#[cfg(all(not(feature = "zlib"), not(feature = "rust_backend")))]
+#[cfg(all(not(feature = "zlib"), not(feature = "rust_backend"), not(target_arch="wasm32")))]
 mod imp {
     extern crate miniz_sys;
     use std::mem;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,17 @@
 
 #[cfg(feature = "tokio")]
 extern crate futures;
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "emscripten"))))]
 extern crate libc;
+#[cfg(all(target_arch = "wasm32", not(target_os = "emscripten")))]
+mod libc {
+    #![allow(non_camel_case_types)]
+    pub type c_ulong = u64;
+    pub type off_t = i64;
+    pub type c_int = i32;
+    pub type c_uint = u32;
+    pub type size_t = usize;
+}
 #[cfg(test)]
 extern crate quickcheck;
 #[cfg(test)]


### PR DESCRIPTION
work in progress.   CC #161 and @wehlutyk and @Frommi 

This takes the work that @wehlutyk did and builds on it by making miniz_oxide_c_api a mandatory requirement if using the wasm32 target.   I don't think this can be merged until we get a new release of miniz_oxide, but I was able to test this change (along with the [zip](https://crates.io/crates/zip) crate) to successfully unzip a .zip file in a browser.

I'm not sure if this is the right long-term approach, but I thought I'd open this PR to share with this success with the community.