### PR TITLE
Add license symlinks to flate2-crc

### DIFF
--- a/flate2-crc/LICENSE-APACHE
+++ b/flate2-crc/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/flate2-crc/LICENSE-MIT
+++ b/flate2-crc/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT


### PR DESCRIPTION
Presumably these use the same text as the parent flate2 project. This
patch makes sure the crates.io artifact includes the license files.