### PR TITLE
Disable compilation of miniz-sys on WASI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,13 @@ jobs:
     - template: ci/azure-install-rust.yml
     - script: rustup target add wasm32-unknown-unknown
     - script: cargo build --target wasm32-unknown-unknown
+- job: wasi
+  steps:
+    - template: ci/azure-install-rust.yml
+      parameters:
+        toolchain: nightly
+    - script: rustup target add wasm32-wasi
+    - script: cargo build --target wasm32-wasi
 - job: rust_backend
   steps:
     - template: ci/azure-install-rust.yml

--- a/miniz-sys/build.rs
+++ b/miniz-sys/build.rs
@@ -4,7 +4,7 @@ use std::env;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
-    if target == "wasm32-unknown-unknown" {
+    if target.starts_with("wasm32-") && !target.ends_with("-emscripten") {
         return;
     }
     let mut build = cc::Build::new();


### PR DESCRIPTION
This aligns build script conditions with all the `#[cfg(...)]` conditions in that miniz-sys shouldn't be attempted to be compiled on WASI target.

In particular, this previously caused library to fail to compile to wasm32-unknown-wasi target from a Windows host.