### PR TITLE
Add `Builder` to configure `Compress`/`Decompress`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod libc {
 pub use crc::{Crc, CrcReader, CrcWriter};
 pub use gz::GzBuilder;
 pub use gz::GzHeader;
-pub use mem::{Compress, CompressError, Decompress, DecompressError, Status};
+pub use mem::{Builder, Compress, CompressError, Decompress, DecompressError, Status};
 pub use mem::{FlushCompress, FlushDecompress};
 
 mod bufreader;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ mod libc {
 pub use crc::{Crc, CrcReader, CrcWriter};
 pub use gz::GzBuilder;
 pub use gz::GzHeader;
-pub use mem::{Builder, Compress, CompressError, Decompress, DecompressError, Status};
+pub use mem::{Compress, CompressError, Decompress, DecompressError, Status};
 pub use mem::{FlushCompress, FlushDecompress};
 
 mod bufreader;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -213,6 +213,11 @@ impl Compress {
     ///
     /// If `window_bits` does not fall into the range 9 ..= 15,
     /// `new_with_window_bits` will panic.
+    ///
+    /// # Note
+    ///
+    /// This constructor is only available when the `zlib` feature is used.
+    /// Other backends currently do not support custom window bits.
     #[cfg(feature = "zlib")]
     pub fn new_with_window_bits(level: Compression, zlib_header: bool, window_bits: u8) -> Compress {
         Compress::make(level, zlib_header, window_bits)
@@ -393,6 +398,11 @@ impl Decompress {
     ///
     /// If `window_bits` does not fall into the range 9 ..= 15,
     /// `new_with_window_bits` will panic.
+    ///
+    /// # Note
+    ///
+    /// This constructor is only available when the `zlib` feature is used.
+    /// Other backends currently do not support custom window bits.
     #[cfg(feature = "zlib")]
     pub fn new_with_window_bits(zlib_header: bool, window_bits: u8) -> Decompress {
         Decompress::make(zlib_header, window_bits)

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -215,6 +215,7 @@ impl<T> Builder<T> {
     /// # Panics
     ///
     /// If `bits` does not fall into the range 9 ..= 15.
+    #[cfg(feature = "zlib")]
     pub fn window_bits(&mut self, bits: u8) -> &mut Self {
         assert!(bits > 8 && bits < 16, "window bits must be within 9 ..= 15");
         self.window_bits = bits as c_int;
@@ -251,7 +252,7 @@ impl Builder<Compress> {
                 9,
                 ffi::MZ_DEFAULT_STRATEGY,
             );
-            debug_assert_eq!(ret, 0);
+            assert_eq!(ret, 0);
             Compress {
                 inner: Stream {
                     stream_wrapper: state,
@@ -277,7 +278,7 @@ impl Builder<Decompress> {
                     -self.window_bits
                 },
             );
-            debug_assert_eq!(ret, 0);
+            assert_eq!(ret, 0);
             Decompress {
                 inner: Stream {
                     stream_wrapper: state,


### PR DESCRIPTION
To allow more control over certain parameters (e.g. the window size) and to not break the existing API, a configuration builder is added in this PR. The control is needed for example to properly implement the permessage-deflate extension of [RFC 7692](https://tools.ietf.org/html/rfc7692#section-7).

I chose to restrict the window bits to the range of 9 ..= 15 (instead of 8 ..= 15), because of zlib's recommendation in [`deflateInit2`](https://www.zlib.net/manual.html#Advanced):

> For the current implementation of `deflate()`, a `windowBits` value of 8 (a window size of 256 bytes) is not supported. As a result, a request for 8 will result in 9 (a 512-byte window). In that case, providing 8 to `inflateInit2()` will result in an error when the *zlib* header with 9 is checked against the initialization of `inflate()`. The remedy is to not use 8 with `deflateInit2()` with this initialization, or at least in that case use 9 with `inflateInit2()`.