### PR TITLE
Expose a few more functions

### DIFF
--- a/src/crc.rs
+++ b/src/crc.rs
@@ -60,6 +60,21 @@ impl Crc {
         self.amt += additional_crc.amt;
         self.hasher.combine(&additional_crc.hasher);
     }
+
+    /// Computes the 8 bytes CRC
+    pub fn to_bytes(&self) -> [u8; 8] {
+        let (sum, amt) = (self.sum() as u32, self.amount());
+        [
+            (sum >> 0) as u8,
+            (sum >> 8) as u8,
+            (sum >> 16) as u8,
+            (sum >> 24) as u8,
+            (amt >> 0) as u8,
+            (amt >> 8) as u8,
+            (amt >> 16) as u8,
+            (amt >> 24) as u8,
+        ]
+    }
 }
 
 impl<R: Read> CrcReader<R> {

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -40,7 +40,8 @@ fn read_le_u16<R: Read>(r: &mut R) -> io::Result<u16> {
     Ok((b[0] as u16) | ((b[1] as u16) << 8))
 }
 
-pub(crate) fn read_gz_header<R: Read>(r: &mut R) -> io::Result<GzHeader> {
+/// Read the Gzip header from a `Read` instance, erroring if the header is missing or invalid.
+pub fn read_gz_header<R: Read>(r: &mut R) -> io::Result<GzHeader> {
     let mut crc_reader = CrcReader::new(r);
     let mut header = [0; 10];
     crc_reader.read_exact(&mut header)?;

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -194,7 +194,8 @@ impl GzBuilder {
         bufread::gz_encoder(self.into_header(lvl), r, lvl)
     }
 
-    fn into_header(self, lvl: Compression) -> Vec<u8> {
+    /// Consume this builder, returning its equivalent in bytes
+    pub fn into_header(self, lvl: Compression) -> Vec<u8> {
         let GzBuilder {
             extra,
             filename,

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -97,17 +97,7 @@ impl<W: Write> GzEncoder<W> {
         self.inner.finish()?;
 
         while self.crc_bytes_written < 8 {
-            let (sum, amt) = (self.crc.sum() as u32, self.crc.amount());
-            let buf = [
-                (sum >> 0) as u8,
-                (sum >> 8) as u8,
-                (sum >> 16) as u8,
-                (sum >> 24) as u8,
-                (amt >> 0) as u8,
-                (amt >> 8) as u8,
-                (amt >> 16) as u8,
-                (amt >> 24) as u8,
-            ];
+            let buf = self.crc.to_bytes();
             let inner = self.inner.get_mut();
             let n = inner.write(&buf[self.crc_bytes_written..])?;
             self.crc_bytes_written += n;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,11 @@ pub mod bufread {
     pub use zlib::bufread::ZlibEncoder;
 }
 
+/// Various functions useful when dealing with `Compression`/`Decompression` directly
+pub mod utils {
+    pub use gz::bufread::read_gz_header;
+}
+
 fn _assert_send_sync() {
     fn _assert_send_sync<T: Send + Sync>() {}
 


### PR DESCRIPTION
I'm building a streaming compression/decompression system with flate2-rs (eg from a multipart upload where you get some chunks once in a while and do not want to keep them in memory once compressed/decompressed) and having those functions public would avoid copying quite a bit of code.
I can't use a fork because of some miniz-sys conflict with some sub-dependencies of actix-web apparently?