### PR TITLE
Upgrade to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "flate2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 version = "1.0.11"
+edition = "2018"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 keywords = ["gzip", "flate", "zlib", "encoding"]

--- a/src/deflate/bufread.rs
+++ b/src/deflate/bufread.rs
@@ -7,8 +7,8 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use zio;
-use {Compress, Decompress};
+use crate::zio;
+use crate::{Compress, Decompress};
 
 /// A DEFLATE encoder, or compressor.
 ///
@@ -50,7 +50,7 @@ pub struct DeflateEncoder<R> {
 impl<R: BufRead> DeflateEncoder<R> {
     /// Creates a new encoder which will read uncompressed data from the given
     /// stream and emit the compressed stream.
-    pub fn new(r: R, level: ::Compression) -> DeflateEncoder<R> {
+    pub fn new(r: R, level: crate::Compression) -> DeflateEncoder<R> {
         DeflateEncoder {
             obj: r,
             data: Compress::new(level, false),

--- a/src/deflate/mod.rs
+++ b/src/deflate/mod.rs
@@ -9,13 +9,13 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use super::{read, write};
-    use Compression;
+    use crate::Compression;
 
     #[test]
     fn roundtrip() {
         let mut real = Vec::new();
         let mut w = write::DeflateEncoder::new(Vec::new(), Compression::default());
-        let v = ::random_bytes().take(1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024).collect::<Vec<_>>();
         for _ in 0..200 {
             let to_write = &v[..thread_rng().gen_range(0, v.len())];
             real.extend(to_write.iter().map(|x| *x));
@@ -44,7 +44,7 @@ mod tests {
     fn total_in() {
         let mut real = Vec::new();
         let mut w = write::DeflateEncoder::new(Vec::new(), Compression::default());
-        let v = ::random_bytes().take(1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024).collect::<Vec<_>>();
         for _ in 0..200 {
             let to_write = &v[..thread_rng().gen_range(0, v.len())];
             real.extend(to_write.iter().map(|x| *x));
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn roundtrip2() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut r =
             read::DeflateDecoder::new(read::DeflateEncoder::new(&v[..], Compression::default()));
         let mut ret = Vec::new();
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn roundtrip3() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut w = write::DeflateEncoder::new(
             write::DeflateDecoder::new(Vec::new()),
             Compression::default(),
@@ -89,7 +89,7 @@ mod tests {
 
     #[test]
     fn reset_writer() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut w = write::DeflateEncoder::new(Vec::new(), Compression::default());
         w.write_all(&v).unwrap();
         let a = w.reset(Vec::new()).unwrap();
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn reset_reader() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let (mut a, mut b, mut c) = (Vec::new(), Vec::new(), Vec::new());
         let mut r = read::DeflateEncoder::new(&v[..], Compression::default());
         r.read_to_end(&mut a).unwrap();
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn reset_decoder() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut w = write::DeflateEncoder::new(Vec::new(), Compression::default());
         w.write_all(&v).unwrap();
         let data = w.finish().unwrap();

--- a/src/deflate/read.rs
+++ b/src/deflate/read.rs
@@ -7,7 +7,7 @@ use futures::Poll;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::bufread;
-use bufreader::BufReader;
+use crate::bufreader::BufReader;
 
 /// A DEFLATE encoder, or compressor.
 ///
@@ -45,7 +45,7 @@ pub struct DeflateEncoder<R> {
 impl<R: Read> DeflateEncoder<R> {
     /// Creates a new encoder which will read uncompressed data from the given
     /// stream and emit the compressed stream.
-    pub fn new(r: R, level: ::Compression) -> DeflateEncoder<R> {
+    pub fn new(r: R, level: crate::Compression) -> DeflateEncoder<R> {
         DeflateEncoder {
             inner: bufread::DeflateEncoder::new(BufReader::new(r), level),
         }

--- a/src/deflate/write.rs
+++ b/src/deflate/write.rs
@@ -6,8 +6,8 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use zio;
-use {Compress, Decompress};
+use crate::zio;
+use crate::{Compress, Decompress};
 
 /// A DEFLATE encoder, or compressor.
 ///
@@ -42,7 +42,7 @@ impl<W: Write> DeflateEncoder<W> {
     ///
     /// When this encoder is dropped or unwrapped the final pieces of data will
     /// be flushed.
-    pub fn new(w: W, level: ::Compression) -> DeflateEncoder<W> {
+    pub fn new(w: W, level: crate::Compression) -> DeflateEncoder<W> {
         DeflateEncoder {
             inner: zio::Writer::new(w, Compress::new(level, false)),
         }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -1,7 +1,7 @@
 //! This module contains backend-specific code.
 
-use mem::{CompressError, DecompressError, FlushCompress, FlushDecompress, Status};
-use Compression;
+use crate::mem::{CompressError, DecompressError, FlushCompress, FlushDecompress, Status};
+use crate::Compression;
 
 pub use self::imp::*;
 
@@ -52,7 +52,7 @@ pub(crate) mod imp {
     pub use libc::{c_int, c_uint, c_void, size_t};
 
     use super::*;
-    use mem::{self, FlushDecompress, Status};
+    use crate::mem::{self, FlushDecompress, Status};
 
     pub struct StreamWrapper {
         pub(crate) inner: Box<mz_stream>,
@@ -481,7 +481,7 @@ mod imp {
     pub const MZ_FINISH: isize = MZFlush::Finish as isize;
 
     use super::*;
-    use mem;
+    use crate::mem;
 
     fn format_from_bool(zlib_header: bool) -> DataFormat {
         if zlib_header {

--- a/src/gz/bufread.rs
+++ b/src/gz/bufread.rs
@@ -10,9 +10,9 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::{GzBuilder, GzHeader};
 use super::{FCOMMENT, FEXTRA, FHCRC, FNAME};
-use crc::CrcReader;
-use deflate;
-use Compression;
+use crate::crc::CrcReader;
+use crate::deflate;
+use crate::Compression;
 
 fn copy(into: &mut [u8], from: &[u8], pos: &mut usize) -> usize {
     let min = cmp::min(into.len(), from.len() - *pos);

--- a/src/gz/mod.rs
+++ b/src/gz/mod.rs
@@ -2,8 +2,8 @@ use std::ffi::CString;
 use std::io::prelude::*;
 use std::time;
 
-use bufreader::BufReader;
-use Compression;
+use crate::bufreader::BufReader;
+use crate::Compression;
 
 pub static FHCRC: u8 = 1 << 1;
 pub static FEXTRA: u8 = 1 << 2;
@@ -257,8 +257,8 @@ mod tests {
     use std::io::prelude::*;
 
     use super::{read, write, GzBuilder};
+    use crate::Compression;
     use rand::{thread_rng, Rng};
-    use Compression;
 
     #[test]
     fn roundtrip() {
@@ -285,7 +285,7 @@ mod tests {
     fn roundtrip_big() {
         let mut real = Vec::new();
         let mut w = write::GzEncoder::new(Vec::new(), Compression::default());
-        let v = ::random_bytes().take(1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024).collect::<Vec<_>>();
         for _ in 0..200 {
             let to_write = &v[..thread_rng().gen_range(0, v.len())];
             real.extend(to_write.iter().map(|x| *x));
@@ -300,7 +300,7 @@ mod tests {
 
     #[test]
     fn roundtrip_big2() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut r = read::GzDecoder::new(read::GzEncoder::new(&v[..], Compression::default()));
         let mut res = Vec::new();
         r.read_to_end(&mut res).unwrap();

--- a/src/gz/read.rs
+++ b/src/gz/read.rs
@@ -8,8 +8,8 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::bufread;
 use super::{GzBuilder, GzHeader};
-use bufreader::BufReader;
-use Compression;
+use crate::bufreader::BufReader;
+use crate::Compression;
 
 /// A gzip streaming encoder
 ///

--- a/src/gz/write.rs
+++ b/src/gz/write.rs
@@ -9,9 +9,9 @@ use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::bufread::{corrupt, read_gz_header};
 use super::{GzBuilder, GzHeader};
-use crc::{Crc, CrcWriter};
-use zio;
-use {Compress, Compression, Decompress, Status};
+use crate::crc::{Crc, CrcWriter};
+use crate::zio;
+use crate::{Compress, Compression, Decompress, Status};
 
 /// A gzip streaming encoder
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,11 +94,11 @@ extern crate rand;
 #[cfg(feature = "tokio")]
 extern crate tokio_io;
 
-pub use crc::{Crc, CrcReader, CrcWriter};
-pub use gz::GzBuilder;
-pub use gz::GzHeader;
-pub use mem::{Compress, CompressError, Decompress, DecompressError, Status};
-pub use mem::{FlushCompress, FlushDecompress};
+pub use crate::crc::{Crc, CrcReader, CrcWriter};
+pub use crate::gz::GzBuilder;
+pub use crate::gz::GzHeader;
+pub use crate::mem::{Compress, CompressError, Decompress, DecompressError, Status};
+pub use crate::mem::{FlushCompress, FlushDecompress};
 
 mod bufreader;
 mod crc;
@@ -114,13 +114,13 @@ mod zlib;
 ///
 /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
 pub mod read {
-    pub use deflate::read::DeflateDecoder;
-    pub use deflate::read::DeflateEncoder;
-    pub use gz::read::GzDecoder;
-    pub use gz::read::GzEncoder;
-    pub use gz::read::MultiGzDecoder;
-    pub use zlib::read::ZlibDecoder;
-    pub use zlib::read::ZlibEncoder;
+    pub use crate::deflate::read::DeflateDecoder;
+    pub use crate::deflate::read::DeflateEncoder;
+    pub use crate::gz::read::GzDecoder;
+    pub use crate::gz::read::GzEncoder;
+    pub use crate::gz::read::MultiGzDecoder;
+    pub use crate::zlib::read::ZlibDecoder;
+    pub use crate::zlib::read::ZlibEncoder;
 }
 
 /// Types which operate over [`Write`] streams, both encoders and decoders for
@@ -128,12 +128,12 @@ pub mod read {
 ///
 /// [`Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 pub mod write {
-    pub use deflate::write::DeflateDecoder;
-    pub use deflate::write::DeflateEncoder;
-    pub use gz::write::GzDecoder;
-    pub use gz::write::GzEncoder;
-    pub use zlib::write::ZlibDecoder;
-    pub use zlib::write::ZlibEncoder;
+    pub use crate::deflate::write::DeflateDecoder;
+    pub use crate::deflate::write::DeflateEncoder;
+    pub use crate::gz::write::GzDecoder;
+    pub use crate::gz::write::GzEncoder;
+    pub use crate::zlib::write::ZlibDecoder;
+    pub use crate::zlib::write::ZlibEncoder;
 }
 
 /// Types which operate over [`BufRead`] streams, both encoders and decoders for
@@ -141,13 +141,13 @@ pub mod write {
 ///
 /// [`BufRead`]: https://doc.rust-lang.org/std/io/trait.BufRead.html
 pub mod bufread {
-    pub use deflate::bufread::DeflateDecoder;
-    pub use deflate::bufread::DeflateEncoder;
-    pub use gz::bufread::GzDecoder;
-    pub use gz::bufread::GzEncoder;
-    pub use gz::bufread::MultiGzDecoder;
-    pub use zlib::bufread::ZlibDecoder;
-    pub use zlib::bufread::ZlibEncoder;
+    pub use crate::deflate::bufread::DeflateDecoder;
+    pub use crate::deflate::bufread::DeflateEncoder;
+    pub use crate::gz::bufread::GzDecoder;
+    pub use crate::gz::bufread::GzEncoder;
+    pub use crate::gz::bufread::MultiGzDecoder;
+    pub use crate::zlib::bufread::ZlibDecoder;
+    pub use crate::zlib::bufread::ZlibEncoder;
 }
 
 fn _assert_send_sync() {

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::io;
 use std::slice;
 
-use ffi::{self, Backend, Deflate, DeflateBackend, Inflate, InflateBackend};
-use Compression;
+use crate::ffi::{self, Backend, Deflate, DeflateBackend, Inflate, InflateBackend};
+use crate::Compression;
 
 /// Raw in-memory compression stream for blocks of data.
 ///
@@ -510,11 +510,11 @@ impl fmt::Display for CompressError {
 mod tests {
     use std::io::Write;
 
-    use write;
-    use {Compression, Decompress, FlushDecompress};
+    use crate::write;
+    use crate::{Compression, Decompress, FlushDecompress};
 
     #[cfg(feature = "zlib")]
-    use {Compress, FlushCompress};
+    use crate::{Compress, FlushCompress};
 
     #[test]
     fn issue51() {

--- a/src/zio.rs
+++ b/src/zio.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::io::prelude::*;
 use std::mem;
 
-use {Compress, Decompress, DecompressError, FlushCompress, FlushDecompress, Status};
+use crate::{Compress, Decompress, DecompressError, FlushCompress, FlushDecompress, Status};
 
 #[derive(Debug)]
 pub struct Writer<W: Write, D: Ops> {

--- a/src/zlib/bufread.rs
+++ b/src/zlib/bufread.rs
@@ -7,8 +7,8 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use zio;
-use {Compress, Decompress};
+use crate::zio;
+use crate::{Compress, Decompress};
 
 /// A ZLIB encoder, or compressor.
 ///
@@ -46,7 +46,7 @@ pub struct ZlibEncoder<R> {
 impl<R: BufRead> ZlibEncoder<R> {
     /// Creates a new encoder which will read uncompressed data from the given
     /// stream and emit the compressed stream.
-    pub fn new(r: R, level: ::Compression) -> ZlibEncoder<R> {
+    pub fn new(r: R, level: crate::Compression) -> ZlibEncoder<R> {
         ZlibEncoder {
             obj: r,
             data: Compress::new(level, true),

--- a/src/zlib/mod.rs
+++ b/src/zlib/mod.rs
@@ -9,14 +9,14 @@ mod tests {
 
     use rand::{thread_rng, Rng};
 
-    use zlib::{read, write};
-    use Compression;
+    use crate::zlib::{read, write};
+    use crate::Compression;
 
     #[test]
     fn roundtrip() {
         let mut real = Vec::new();
         let mut w = write::ZlibEncoder::new(Vec::new(), Compression::default());
-        let v = ::random_bytes().take(1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024).collect::<Vec<_>>();
         for _ in 0..200 {
             let to_write = &v[..thread_rng().gen_range(0, v.len())];
             real.extend(to_write.iter().map(|x| *x));
@@ -45,7 +45,7 @@ mod tests {
     fn total_in() {
         let mut real = Vec::new();
         let mut w = write::ZlibEncoder::new(Vec::new(), Compression::default());
-        let v = ::random_bytes().take(1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024).collect::<Vec<_>>();
         for _ in 0..200 {
             let to_write = &v[..thread_rng().gen_range(0, v.len())];
             real.extend(to_write.iter().map(|x| *x));
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn roundtrip2() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut r = read::ZlibDecoder::new(read::ZlibEncoder::new(&v[..], Compression::default()));
         let mut ret = Vec::new();
         r.read_to_end(&mut ret).unwrap();
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn roundtrip3() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut w =
             write::ZlibEncoder::new(write::ZlibDecoder::new(Vec::new()), Compression::default());
         w.write_all(&v).unwrap();
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn reset_decoder() {
-        let v = ::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
+        let v = crate::random_bytes().take(1024 * 1024).collect::<Vec<_>>();
         let mut w = write::ZlibEncoder::new(Vec::new(), Compression::default());
         w.write_all(&v).unwrap();
         let data = w.finish().unwrap();

--- a/src/zlib/read.rs
+++ b/src/zlib/read.rs
@@ -7,7 +7,7 @@ use futures::Poll;
 use tokio_io::{AsyncRead, AsyncWrite};
 
 use super::bufread;
-use bufreader::BufReader;
+use crate::bufreader::BufReader;
 
 /// A ZLIB encoder, or compressor.
 ///
@@ -42,7 +42,7 @@ pub struct ZlibEncoder<R> {
 impl<R: Read> ZlibEncoder<R> {
     /// Creates a new encoder which will read uncompressed data from the given
     /// stream and emit the compressed stream.
-    pub fn new(r: R, level: ::Compression) -> ZlibEncoder<R> {
+    pub fn new(r: R, level: crate::Compression) -> ZlibEncoder<R> {
         ZlibEncoder {
             inner: bufread::ZlibEncoder::new(BufReader::new(r), level),
         }

--- a/src/zlib/write.rs
+++ b/src/zlib/write.rs
@@ -6,8 +6,8 @@ use futures::Poll;
 #[cfg(feature = "tokio")]
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use zio;
-use {Compress, Decompress};
+use crate::zio;
+use crate::{Compress, Decompress};
 
 /// A ZLIB encoder, or compressor.
 ///
@@ -43,7 +43,7 @@ impl<W: Write> ZlibEncoder<W> {
     ///
     /// When this encoder is dropped or unwrapped the final pieces of data will
     /// be flushed.
-    pub fn new(w: W, level: ::Compression) -> ZlibEncoder<W> {
+    pub fn new(w: W, level: crate::Compression) -> ZlibEncoder<W> {
         ZlibEncoder {
             inner: zio::Writer::new(w, Compress::new(level, true)),
         }


### PR DESCRIPTION
This PR upgrades the crate to the 2018 edition of Rust. Tests pass on both the latest stable and latest nightly versions. 

closes #212