### PR TITLE
feat: allow full range of window bits for zlib

### DIFF
--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -163,10 +163,10 @@ pub struct Inflate {
 }
 
 impl InflateBackend for Inflate {
-    fn make(zlib_header: bool, window_bits: u8) -> Self {
+    fn make(zlib_header: bool, window_bits: i32) -> Self {
         assert!(
-            window_bits > 8 && window_bits < 16,
-            "window_bits must be within 9 ..= 15"
+            window_bits > -16 && window_bits < 48,
+            "window_bits must be within -15 ..= 47"
         );
         unsafe {
             let mut state = StreamWrapper::default();
@@ -257,7 +257,7 @@ pub struct Deflate {
 }
 
 impl DeflateBackend for Deflate {
-    fn make(level: Compression, zlib_header: bool, window_bits: u8) -> Self {
+    fn make(level: Compression, zlib_header: bool, window_bits: i32) -> Self {
         assert!(
             window_bits > 8 && window_bits < 16,
             "window_bits must be within 9 ..= 15"

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -235,7 +235,7 @@ impl InflateBackend for Inflate {
 
     #[cfg(not(feature = "any_zlib"))]
     fn reset(&mut self, zlib_header: bool) {
-        *self = Self::make(zlib_header, MZ_DEFAULT_WINDOW_BITS as u8);
+        *self = Self::make(zlib_header, MZ_DEFAULT_WINDOW_BITS);
     }
 }
 

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -172,7 +172,7 @@ impl InflateBackend for Inflate {
             let mut state = StreamWrapper::default();
             let ret = mz_inflateInit2(
                 &mut *state,
-                if zlib_header {
+                if zlib_header || window_bits > 15 {
                     window_bits as c_int
                 } else {
                     -(window_bits as c_int)

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -13,7 +13,7 @@ pub trait Backend: Sync + Send {
 }
 
 pub trait InflateBackend: Backend {
-    fn make(zlib_header: bool, window_bits: u8) -> Self;
+    fn make(zlib_header: bool, window_bits: i32) -> Self;
     fn decompress(
         &mut self,
         input: &[u8],
@@ -24,7 +24,7 @@ pub trait InflateBackend: Backend {
 }
 
 pub trait DeflateBackend: Backend {
-    fn make(level: Compression, zlib_header: bool, window_bits: u8) -> Self;
+    fn make(level: Compression, zlib_header: bool, window_bits: i32) -> Self;
     fn compress(
         &mut self,
         input: &[u8],

--- a/src/ffi/rust.rs
+++ b/src/ffi/rust.rs
@@ -41,7 +41,7 @@ impl fmt::Debug for Inflate {
 }
 
 impl InflateBackend for Inflate {
-    fn make(zlib_header: bool, window_bits: u8) -> Self {
+    fn make(zlib_header: bool, window_bits: i32) -> Self {
         assert!(
             window_bits > 8 && window_bits < 16,
             "window_bits must be within 9 ..= 15"
@@ -119,7 +119,7 @@ impl fmt::Debug for Deflate {
 }
 
 impl DeflateBackend for Deflate {
-    fn make(level: Compression, zlib_header: bool, window_bits: u8) -> Self {
+    fn make(level: Compression, zlib_header: bool, window_bits: i32) -> Self {
         assert!(
             window_bits > 8 && window_bits < 16,
             "window_bits must be within 9 ..= 15"

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -188,7 +188,7 @@ impl Compress {
     /// output data should have a zlib header or not.
     pub fn new(level: Compression, zlib_header: bool) -> Compress {
         Compress {
-            inner: Deflate::make(level, zlib_header, ffi::MZ_DEFAULT_WINDOW_BITS as u8),
+            inner: Deflate::make(level, zlib_header, ffi::MZ_DEFAULT_WINDOW_BITS),
         }
     }
 
@@ -213,7 +213,7 @@ impl Compress {
     pub fn new_with_window_bits(
         level: Compression,
         zlib_header: bool,
-        window_bits: u8,
+        window_bits: i32,
     ) -> Compress {
         Compress {
             inner: Deflate::make(level, zlib_header, window_bits),
@@ -334,7 +334,7 @@ impl Decompress {
     /// to have a zlib header or not.
     pub fn new(zlib_header: bool) -> Decompress {
         Decompress {
-            inner: Inflate::make(zlib_header, ffi::MZ_DEFAULT_WINDOW_BITS as u8),
+            inner: Inflate::make(zlib_header, ffi::MZ_DEFAULT_WINDOW_BITS),
         }
     }
 
@@ -354,7 +354,7 @@ impl Decompress {
     /// This constructor is only available when the `zlib` feature is used.
     /// Other backends currently do not support custom window bits.
     #[cfg(feature = "any_zlib")]
-    pub fn new_with_window_bits(zlib_header: bool, window_bits: u8) -> Decompress {
+    pub fn new_with_window_bits(zlib_header: bool, window_bits: i32) -> Decompress {
         Decompress {
             inner: Inflate::make(zlib_header, window_bits),
         }


### PR DESCRIPTION
According to https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/zlib.h#L839-L870 the Window Bits parameter for `inflateInit2` should support values in the range of -15 to 47. This PR allows for those ranges in the C implementation. 