### PR TITLE
Cargo.toml: rewrite description, no longer "bindings to miniz.c"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ repository = "https://github.com/alexcrichton/flate2-rs"
 homepage = "https://github.com/alexcrichton/flate2-rs"
 documentation = "https://docs.rs/flate2"
 description = """
-Bindings to miniz.c for DEFLATE compression and decompression exposed as
-Reader/Writer streams. Contains bindings for zlib, deflate, and gzip-based
-streams.
+DEFLATE compression and decompression exposed as Read/BufRead/Write streams.
+Supports miniz_oxide, miniz.c, and multiple zlib implementations. Supports
+zlib, gzip, and raw deflate streams.
 """
 
 [workspace]


### PR DESCRIPTION
flate2 does not just provide "bindings to miniz.c", and in fact doesn't
use miniz.c by default. Rewrite the description for clarity.