### PR TITLE
Update to libz-sys 1.1.0, and support use with zlib-ng

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
     - run: cargo test --features zlib
     - run: cargo test --features miniz-sys
     - run: cargo test --features zlib --no-default-features
+    - run: cargo test --features zlib-ng-compat --no-default-features
     - run: cargo test --features cloudflare_zlib --no-default-features
       if: matrix.build != 'mingw'
     - run: cargo test --features miniz-sys --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = ['systest']
 libc = "0.2.65"
 cfg-if = "0.1.6"
 miniz-sys = { path = "miniz-sys", version = "0.1.11", optional = true }
-libz-sys = { version = "1.0.25", optional = true }
+libz-sys = { version = "1.1.0", optional = true, default-features = false }
 cloudflare-zlib-sys = { version = "0.2.0", optional = true }
 tokio-io = { version = "0.1.11", optional = true }
 futures = { version = "0.1.25", optional = true }
@@ -46,6 +46,7 @@ futures = "0.1"
 default = ["rust_backend"]
 any_zlib = [] # note: this is not a real user-facing feature
 zlib = ["any_zlib", "libz-sys"]
+zlib-ng-compat = ["zlib", "libz-sys/zlib-ng"]
 cloudflare_zlib = ["any_zlib", "cloudflare-zlib-sys"]
 rust_backend = ["miniz_oxide"]
 tokio = ["tokio-io", "futures"]

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 A streaming compression/decompression library DEFLATE-based streams in Rust.
 
-This crate by default implemented as a wrapper around the `miniz_oxide` crate, a
-port of `miniz.c` to Rust. This crate can also optionally use other [backends](#Backends) like the zlib library
-or `miniz.c` itself.
+This crate by default uses the `miniz_oxide` crate, a port of `miniz.c` to pure
+Rust. This crate also supports other [backends](#Backends), such as the widely
+available zlib library or the high-performance zlib-ng library.
 
 Supported formats:
 
@@ -52,29 +52,40 @@ fn main() {
 
 ## Backends
 
-Using zlib instead of the (default) Rust backend:
+The default `miniz_oxide` backend has the advantage of being pure Rust, but it
+has relatively low performance. For higher performance, you can use zlib
+instead:
 
 ```toml
 [dependencies]
 flate2 = { version = "1.0", features = ["zlib"], default-features = false }
 ```
 
-The cloudflare optimized version of zlib is also available.
-While it's significantly faster it requires a x86-64 CPU with SSE 4.2 or ARM64 with NEON & CRC.
-It does not support 32-bit CPUs at all and is incompatible with mingw.
-For more information check the [crate documentation](https://crates.io/crates/cloudflare-zlib-sys).
+This supports either the high-performance zlib-ng backend (in zlib-compat mode)
+or the use of a shared system zlib library. To explicitly opt into the fast
+zlib-ng backend, use:
 
 ```toml
 [dependencies]
-flate2 = { version = "1.0", features = ["cloudflare_zlib"], default-features = false }
+flate2 = { version = "1.0", features = ["zlib-ng-compat"], default-features = false }
 ```
 
-Using `miniz.c`:
+Note that if any crate in your dependency graph explicitly requests stock zlib,
+or uses libz-sys directly without `default-features = false`, you'll get stock
+zlib rather than zlib-ng. See [the libz-sys
+README](https://github.com/rust-lang/libz-sys/blob/main/README.md) for details.
 
-```toml
-[dependencies]
-flate2 = { version = "1.0", features = ["miniz-sys"], default-features = false }
-```
+For compatibility with previous versions of `flate2`, the cloudflare optimized
+version of zlib is available, via the `cloudflare_zlib` feature. It's not as
+fast as zlib-ng, but it's faster than stock zlib. It requires a x86-64 CPU with
+SSE 4.2 or ARM64 with NEON & CRC. It does not support 32-bit CPUs at all and is
+incompatible with mingw. For more information check the [crate
+documentation](https://crates.io/crates/cloudflare-zlib-sys). Note that
+`cloudflare_zlib` will cause breakage if any other crate in your crate graph
+uses another version of zlib/libz.
+
+For compatibility with previous versions of `flate2`, the C version of `miniz.c`
+is still available, using the feature `miniz-sys`.
 
 # License
 

--- a/src/ffi/c.rs
+++ b/src/ffi/c.rs
@@ -345,7 +345,10 @@ mod c_backend {
 }
 
 /// Zlib specific
-#[cfg(all(feature = "zlib", not(feature = "cloudflare_zlib")))]
+#[cfg(any(
+    feature = "zlib-ng-compat",
+    all(feature = "zlib", not(feature = "cloudflare_zlib"))
+))]
 #[allow(bad_style)]
 mod c_backend {
     use libc::{c_char, c_int};
@@ -409,7 +412,7 @@ mod c_backend {
 }
 
 /// Cloudflare optimized Zlib specific
-#[cfg(feature = "cloudflare_zlib")]
+#[cfg(all(feature = "cloudflare_zlib", not(feature = "zlib-ng-compat")))]
 #[allow(bad_style)]
 mod c_backend {
     use libc::{c_char, c_int};

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -36,7 +36,7 @@ pub trait DeflateBackend: Backend {
 
 // Default to Rust implementation unless explicitly opted in to a different backend.
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "miniz-sys", feature = "zlib", feature = "cloudflare_zlib"))] {
+    if #[cfg(any(feature = "miniz-sys", feature = "any_zlib"))] {
         mod c;
         pub use self::c::*;
     } else {


### PR DESCRIPTION
libz-sys 1.1.0 introduces optional support for zlib-ng, if the default
`stock-zlib` feature is disabled and the `zlib-ng` feature is enabled.
Modify the dependency on libz-sys to disable the `stock-zlib` feature,
which allows crates using flate2 to opt into zlib-ng if they wish. Add a
`zlib-ng-compat` feature to flate2, to opt into zlib-ng explicitly.

Update the README to document this, and to describe some of the
tradeoffs between zlib implementations.